### PR TITLE
Show submit/evaluate button by default on 'PatientInfoForm'.

### DIFF
--- a/src/components/PatientInfoForm.js
+++ b/src/components/PatientInfoForm.js
@@ -213,6 +213,7 @@ class PatientInfoForm extends Component {
                             <div className="upload-btn-wrapper mb-2">
                               <button className="upload-btn bg-primary">Upload X-Ray</button>
                               <input name="image" type="file" onChange={ e => {
+                                document.getElementById('submitDetails').disabled = false;
                                 this.props.setXrayImage(e.currentTarget.files[0] )
                               }} />
                             </div>
@@ -225,6 +226,7 @@ class PatientInfoForm extends Component {
                             <div className="upload-btn-wrapper mb-2">
                               <button className="upload-btn bg-primary">Upload CT-Scan</button>
                               <input name="image" type="file" onChange={ e => {
+                                document.getElementById('submitDetails').disabled = false;
                                 this.props.setXrayImage(e.currentTarget.files[0] )
                               }} />
                             </div>
@@ -233,14 +235,15 @@ class PatientInfoForm extends Component {
                           <Preview file={this.props.ctscan_image} />
                         </div>
 
-                      { this.props.xray_image ? <div className="col-md-12">
+                    <div className="col-md-12">
                       <div className="mt-4 d-flex justify-content-center">
-                      <button className="btn bg-warning text-dark mt-3" onClick={this.Upload_To_AWS_S3_and_Run_ML_Model} style={{
-                                        paddingRight:'40px',
-                                        paddingLeft: '40px'
-                                    }}>
-                        { this.props.loading ? 'Uploading...' : 'Evaluate' }</button>
-                    </div></div> : null }
+                        <button className="btn bg-warning text-dark mt-3" id="submitDetails" disabled
+                                onClick={this.Upload_To_AWS_S3_and_Run_ML_Model}
+                                style={{ paddingRight:'40px',paddingLeft: '40px'}}>
+                            { this.props.loading ? 'Uploading...' : 'Evaluate' }
+                        </button>
+                      </div>
+                    </div>
 
                     </div>
                 </div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -117,6 +117,10 @@ a.active {
   border-color: #86c6f8 !important;
 }
 
+.btn:disabled {
+  cursor: not-allowed;
+}
+
 .card-footer-banner {
   margin-top: 17px;
   border-top: 2px solid #a7d7fe;


### PR DESCRIPTION
Issue: Currently 'Evaluate' button only appear once image is uploaded,
       it's not obvious for new user and they might consider it as a bug
       as there is no button to submit the form.

Solution: Showing 'Evaluate' button by default on form, but only
          enabling it once image is uploaded.